### PR TITLE
feat: Add download functionality and complete file management

### DIFF
--- a/src/main/java/com/solidwall/tartib/controllers/AutorisationController.java
+++ b/src/main/java/com/solidwall/tartib/controllers/AutorisationController.java
@@ -1,0 +1,125 @@
+package com.solidwall.tartib.controllers;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solidwall.tartib.core.helpers.CustomResponseHelper;
+import com.solidwall.tartib.dto.autorisation.CreateDto;
+import com.solidwall.tartib.dto.autorisation.UpdateDto;
+import com.solidwall.tartib.entities.AutorisationEntity;
+import com.solidwall.tartib.implementations.AutorisationImplementation;
+import com.solidwall.tartib.services.AutorisationService;
+import com.solidwall.tartib.core.exceptions.NotFoundException;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+
+
+@RestController
+@RequestMapping("autorisation")
+public class AutorisationController {
+
+    @Autowired
+    private AutorisationImplementation autorisationImplementation;
+
+    @Autowired
+    private AutorisationService autorisationService;
+
+    @PostMapping(value = "create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CustomResponseHelper<AutorisationEntity>> create(@ModelAttribute CreateDto data) {
+        CustomResponseHelper<AutorisationEntity> response = CustomResponseHelper.<AutorisationEntity>builder()
+                .body(autorisationImplementation.create(data))
+                .message("Autorisation created successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @PutMapping(value = "update/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CustomResponseHelper<AutorisationEntity>> update(@PathVariable Long id,
+            @ModelAttribute UpdateDto data) {
+        CustomResponseHelper<AutorisationEntity> response = CustomResponseHelper.<AutorisationEntity>builder()
+                .body(autorisationImplementation.update(id, data))
+                .message("Autorisation updated successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("get/{id}")
+    public ResponseEntity<CustomResponseHelper<AutorisationEntity>> getOne(@PathVariable Long id) {
+        CustomResponseHelper<AutorisationEntity> response = CustomResponseHelper.<AutorisationEntity>builder()
+                .body(autorisationImplementation.getOne(id))
+                .message("Autorisation retrieved successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("all")
+    public ResponseEntity<CustomResponseHelper<List<AutorisationEntity>>> findAll() {
+        CustomResponseHelper<List<AutorisationEntity>> response = CustomResponseHelper
+                .<List<AutorisationEntity>>builder()
+                .body(autorisationImplementation.findAll())
+                .message("Autorisations list retrieved successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @DeleteMapping("delete/{id}")
+    public ResponseEntity<CustomResponseHelper<Void>> delete(@PathVariable Long id) {
+        autorisationImplementation.delete(id);
+        CustomResponseHelper<Void> response = CustomResponseHelper.<Void>builder()
+                .message("Autorisation deleted successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("/download/{id}")
+    public ResponseEntity<Resource> downloadFile(@PathVariable Long id) {
+        try {
+            Resource fileResource = autorisationService.downloadJustificationFile(id);
+
+            AutorisationEntity autorisation = autorisationImplementation.getOne(id);
+
+            String contentType = autorisationService.determineContentType(autorisation.getJustificationPath());
+
+            return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" +
+                        fileResource.getFilename() + "\"")
+                .body(fileResource);
+
+        } catch (NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/solidwall/tartib/controllers/NomenclatureSecteurController.java
+++ b/src/main/java/com/solidwall/tartib/controllers/NomenclatureSecteurController.java
@@ -40,7 +40,7 @@ public class NomenclatureSecteurController {
         return ResponseEntity.status(response.getStatus()).body(response);
             }
 
-    @PutMapping("update/{id}")
+    @PutMapping(value = "update/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CustomResponseHelper<NomenclatureSecteurEntity>> update(
             @PathVariable Long id,
             @ModelAttribute UpdateNomenclatureSecteurDto data) {

--- a/src/main/java/com/solidwall/tartib/controllers/ProjectLogicController.java
+++ b/src/main/java/com/solidwall/tartib/controllers/ProjectLogicController.java
@@ -10,9 +10,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +22,10 @@ import com.solidwall.tartib.dto.project.logic.CreateDto;
 import com.solidwall.tartib.dto.project.logic.UpdateDto;
 import com.solidwall.tartib.entities.ProjectLogicEntity;
 import com.solidwall.tartib.implementations.ProjectLogicImplementation;
+import com.solidwall.tartib.services.ProjectLogicService;
+import com.solidwall.tartib.core.exceptions.NotFoundException;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 
 @RestController
 @RequestMapping("project-logic")
@@ -28,6 +33,9 @@ public class ProjectLogicController {
 
   @Autowired
   ProjectLogicImplementation projectLogicImplementation;
+
+  @Autowired
+  ProjectLogicService projectLogicService;
 
   @GetMapping("all")
   public ResponseEntity<CustomResponseHelper<List<ProjectLogicEntity>>> findAll() {
@@ -79,8 +87,8 @@ public class ProjectLogicController {
     return ResponseEntity.status(response.getStatus()).body(response);
   }
 
-  @PostMapping({ "create" })
-  private ResponseEntity<CustomResponseHelper<ProjectLogicEntity>> create(@RequestBody CreateDto data) {
+  @PostMapping(value = "create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  private ResponseEntity<CustomResponseHelper<ProjectLogicEntity>> create(@ModelAttribute CreateDto data) {
     CustomResponseHelper<ProjectLogicEntity> response = CustomResponseHelper.<ProjectLogicEntity>builder()
         .body(projectLogicImplementation.create(data))
         .message("project logic created successfully")
@@ -91,9 +99,9 @@ public class ProjectLogicController {
     return ResponseEntity.status(response.getStatus()).body(response);
   }
 
-  @PutMapping({ "update/{id}" })
+  @PutMapping(value = "update/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   private ResponseEntity<CustomResponseHelper<ProjectLogicEntity>> update(@PathVariable("id") Long id,
-      @RequestBody UpdateDto data) {
+      @ModelAttribute UpdateDto data) {
     CustomResponseHelper<ProjectLogicEntity> response = CustomResponseHelper.<ProjectLogicEntity>builder()
         .body(projectLogicImplementation.update(id, data))
         .message("project logic updated successfully")
@@ -114,5 +122,49 @@ public class ProjectLogicController {
         .timestamp(new Date())
         .build();
     return ResponseEntity.status(response.getStatus()).body(response);
+  }
+
+  @GetMapping("/download/cadre/{id}")
+  public ResponseEntity<Resource> downloadCadreFile(@PathVariable Long id) {
+      try {
+          Resource fileResource = projectLogicService.downloadDocumentCadreFile(id);
+
+          ProjectLogicEntity projectLogic = projectLogicImplementation.getOne(id);
+
+          String contentType = projectLogicService.determineContentType(projectLogic.getDocumentCadre());
+
+          return ResponseEntity.ok()
+              .contentType(MediaType.parseMediaType(contentType))
+              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" +
+                      fileResource.getFilename() + "\"")
+              .body(fileResource);
+
+      } catch (NotFoundException e) {
+          return ResponseEntity.notFound().build();
+      } catch (Exception e) {
+          return ResponseEntity.internalServerError().build();
+      }
+  }
+
+  @GetMapping("/download/plan-travail/{id}")
+  public ResponseEntity<Resource> downloadPlanTravailFile(@PathVariable Long id) {
+      try {
+          Resource fileResource = projectLogicService.downloadDocumentPlanTravailFile(id);
+
+          ProjectLogicEntity projectLogic = projectLogicImplementation.getOne(id);
+
+          String contentType = projectLogicService.determineContentType(projectLogic.getDocumentPlanTravail());
+
+          return ResponseEntity.ok()
+              .contentType(MediaType.parseMediaType(contentType))
+              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" +
+                      fileResource.getFilename() + "\"")
+              .body(fileResource);
+
+      } catch (NotFoundException e) {
+          return ResponseEntity.notFound().build();
+      } catch (Exception e) {
+          return ResponseEntity.internalServerError().build();
+      }
   }
 }

--- a/src/main/java/com/solidwall/tartib/controllers/StudyForProjectController.java
+++ b/src/main/java/com/solidwall/tartib/controllers/StudyForProjectController.java
@@ -1,0 +1,122 @@
+package com.solidwall.tartib.controllers;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solidwall.tartib.core.helpers.CustomResponseHelper;
+import com.solidwall.tartib.dto.studyforproject.CreateDto;
+import com.solidwall.tartib.dto.studyforproject.UpdateDto;
+import com.solidwall.tartib.entities.StudyForProject;
+import com.solidwall.tartib.implementations.StudyForProjectImplementation;
+import com.solidwall.tartib.services.StudyForProjectService;
+import com.solidwall.tartib.core.exceptions.NotFoundException;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+
+@RestController
+@RequestMapping("study-for-project")
+public class StudyForProjectController {
+
+    @Autowired
+    private StudyForProjectImplementation studyForProjectImplementation;
+
+    @Autowired
+    private StudyForProjectService studyForProjectService;
+
+    @PostMapping(value = "create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CustomResponseHelper<StudyForProject>> create(@ModelAttribute CreateDto data) {
+        CustomResponseHelper<StudyForProject> response = CustomResponseHelper.<StudyForProject>builder()
+                .body(studyForProjectImplementation.create(data))
+                .message("StudyForProject created successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @PutMapping(value = "update/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CustomResponseHelper<StudyForProject>> update(@PathVariable Long id,
+            @ModelAttribute UpdateDto data) {
+        CustomResponseHelper<StudyForProject> response = CustomResponseHelper.<StudyForProject>builder()
+                .body(studyForProjectImplementation.update(id, data))
+                .message("StudyForProject updated successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("get/{id}")
+    public ResponseEntity<CustomResponseHelper<StudyForProject>> getOne(@PathVariable Long id) {
+        CustomResponseHelper<StudyForProject> response = CustomResponseHelper.<StudyForProject>builder()
+                .body(studyForProjectImplementation.getOne(id))
+                .message("StudyForProject retrieved successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("all")
+    public ResponseEntity<CustomResponseHelper<List<StudyForProject>>> findAll() {
+        CustomResponseHelper<List<StudyForProject>> response = CustomResponseHelper
+                .<List<StudyForProject>>builder()
+                .body(studyForProjectImplementation.findAll())
+                .message("StudyForProjects list retrieved successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @DeleteMapping("delete/{id}")
+    public ResponseEntity<CustomResponseHelper<Void>> delete(@PathVariable Long id) {
+        studyForProjectImplementation.delete(id);
+        CustomResponseHelper<Void> response = CustomResponseHelper.<Void>builder()
+                .message("StudyForProject deleted successfully")
+                .error(false)
+                .status(HttpStatus.OK.value())
+                .timestamp(new Date())
+                .build();
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @GetMapping("/download/{id}")
+    public ResponseEntity<Resource> downloadFile(@PathVariable Long id) {
+        try {
+            Resource fileResource = studyForProjectService.downloadStudyFile(id);
+
+            StudyForProject studyForProject = studyForProjectImplementation.getOne(id);
+
+            String contentType = studyForProjectService.determineContentType(studyForProject.getStudyFile());
+
+            return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" +
+                        fileResource.getFilename() + "\"")
+                .body(fileResource);
+
+        } catch (NotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/solidwall/tartib/dto/autorisation/CreateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/autorisation/CreateDto.java
@@ -1,5 +1,7 @@
 package com.solidwall.tartib.dto.autorisation;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,6 +12,7 @@ public class CreateDto {
     private String name;
     private String validateur;
     private String observation;
+    private MultipartFile justificationFile;
 
 
 

--- a/src/main/java/com/solidwall/tartib/dto/autorisation/UpdateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/autorisation/UpdateDto.java
@@ -1,5 +1,7 @@
 package com.solidwall.tartib.dto.autorisation;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,5 +12,6 @@ public class UpdateDto {
     private String name;
     private String validateur;
     private String observation;
+    private MultipartFile justificationFile;
 
 }

--- a/src/main/java/com/solidwall/tartib/dto/project/logic/CreateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/project/logic/CreateDto.java
@@ -14,9 +14,9 @@ public class CreateDto {
     private String generalObjective;
     private String specific_objective;
     private String results;
-    private String documentCadre;
+    private org.springframework.web.multipart.MultipartFile documentCadreFile;
     private String yearStart;
     private String yearEnd;
-    private String documentPlanTravail;
+    private org.springframework.web.multipart.MultipartFile documentPlanTravailFile;
 
 }

--- a/src/main/java/com/solidwall/tartib/dto/project/logic/UpdateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/project/logic/UpdateDto.java
@@ -16,8 +16,8 @@ public class UpdateDto {
     private String generalObjective;
     private String specific_objective;
     private String results;
-    private String documentCadre;
+    private org.springframework.web.multipart.MultipartFile documentCadreFile;
     private String yearStart;
     private String yearEnd;
-    private String documentPlanTravail;
+    private org.springframework.web.multipart.MultipartFile documentPlanTravailFile;
 }

--- a/src/main/java/com/solidwall/tartib/dto/project/plan/CreateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/project/plan/CreateDto.java
@@ -26,4 +26,6 @@ public class CreateDto {
   private String observation;
 
   private Long montantAnnuel;
+
+  private org.springframework.web.multipart.MultipartFile planFinancementFile;
 }

--- a/src/main/java/com/solidwall/tartib/dto/project/plan/UpdateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/project/plan/UpdateDto.java
@@ -24,4 +24,6 @@ public class UpdateDto {
   private String observation;
 
   private Long montantAnnuel;
+
+  private org.springframework.web.multipart.MultipartFile planFinancementFile;
 }

--- a/src/main/java/com/solidwall/tartib/dto/studyforproject/CreateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/studyforproject/CreateDto.java
@@ -1,5 +1,7 @@
 package com.solidwall.tartib.dto.studyforproject;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,4 +17,6 @@ public class CreateDto {
     private String description;
 
     private Date realisationDate;
+
+    private MultipartFile studyFile;
 }

--- a/src/main/java/com/solidwall/tartib/dto/studyforproject/UpdateDto.java
+++ b/src/main/java/com/solidwall/tartib/dto/studyforproject/UpdateDto.java
@@ -1,5 +1,7 @@
 package com.solidwall.tartib.dto.studyforproject;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.Getter;
 import lombok.Setter;
 import java.sql.Date;
@@ -13,4 +15,6 @@ public class UpdateDto {
     private String description;
 
     private Date realisationDate;
+
+    private MultipartFile studyFile;
 }

--- a/src/main/java/com/solidwall/tartib/entities/AutorisationEntity.java
+++ b/src/main/java/com/solidwall/tartib/entities/AutorisationEntity.java
@@ -30,5 +30,8 @@ public class AutorisationEntity extends AbstractBaseEntity {
     private String validateur;
     @Column(name = "observation", length = 255, nullable = true)
     private String observation;
+
+    @Column(name = "justification_path", length = 1000)
+    private String justificationPath;
      
 }

--- a/src/main/java/com/solidwall/tartib/entities/ProjectPlanEntity.java
+++ b/src/main/java/com/solidwall/tartib/entities/ProjectPlanEntity.java
@@ -51,4 +51,6 @@ public class ProjectPlanEntity extends AbstractBaseEntity {
     @OneToMany(mappedBy = "projectPlan", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<RubriqueEntity> rubriques = new ArrayList<>();
 
+    @Column(name = "plan_financement", length = 1000)
+    private String planFinancement;
 }

--- a/src/main/java/com/solidwall/tartib/entities/StudyForProject.java
+++ b/src/main/java/com/solidwall/tartib/entities/StudyForProject.java
@@ -39,6 +39,7 @@ public class StudyForProject extends AbstractBaseEntity {
     @Column(name = "realisation_date", nullable = true)
     private Date realisationDate;
 
-    
+    @Column(name = "study_file", length = 1000)
+    private String studyFile;
 
 }

--- a/src/main/java/com/solidwall/tartib/implementations/StudyForProjectImplementation.java
+++ b/src/main/java/com/solidwall/tartib/implementations/StudyForProjectImplementation.java
@@ -1,0 +1,22 @@
+package com.solidwall.tartib.implementations;
+
+import java.util.List;
+import java.util.Map;
+
+import com.solidwall.tartib.dto.studyforproject.CreateDto;
+import com.solidwall.tartib.dto.studyforproject.UpdateDto;
+import com.solidwall.tartib.entities.StudyForProject;
+
+public interface StudyForProjectImplementation {
+    List<StudyForProject> findAll();
+
+    StudyForProject getOne(Long id);
+
+    StudyForProject findOne(Map<String, String> data);
+
+    StudyForProject create(CreateDto data);
+
+    StudyForProject update(Long id, UpdateDto data);
+
+    void delete(Long id);
+}

--- a/src/main/java/com/solidwall/tartib/services/NomenclatureSecteurService.java
+++ b/src/main/java/com/solidwall/tartib/services/NomenclatureSecteurService.java
@@ -37,6 +37,7 @@ import com.solidwall.tartib.repositories.NomenclatureSecteurRepository;
 import com.solidwall.tartib.repositories.SecteurRepository;
 import com.solidwall.tartib.repositories.MinisterRepository;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 @Service
@@ -44,8 +45,19 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NomenclatureSecteurService  implements NomenclatureSecteurImplementation {
     
-    @Value("${app.upload.nomenclature-docs}")
+    @Value("${app.upload.nomenclautre-sectoriel-docs}")
     private String uploadPath;
+
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(Path.of(uploadPath));
+            log.info("Upload directory created/verified: {}", uploadPath);
+        } catch (IOException e) {
+            log.error("Could not create upload directory: {}", uploadPath, e);
+            throw new RuntimeException("Could not create upload directory", e);
+        }
+    }
     
     @Autowired
     private NomenclatureSecteurRepository nomenclatureRepository;

--- a/src/main/java/com/solidwall/tartib/services/ProjectLogicService.java
+++ b/src/main/java/com/solidwall/tartib/services/ProjectLogicService.java
@@ -1,178 +1,268 @@
 package com.solidwall.tartib.services;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.solidwall.tartib.core.exceptions.BadRequestException;
+import com.solidwall.tartib.core.exceptions.FileStorageException;
 import com.solidwall.tartib.core.exceptions.NotFoundException;
 import com.solidwall.tartib.dto.project.logic.CreateDto;
 import com.solidwall.tartib.dto.project.logic.UpdateDto;
+import com.solidwall.tartib.entities.ComponentLogicEntity;
 import com.solidwall.tartib.entities.ProjectIdentityEntity;
 import com.solidwall.tartib.entities.ProjectLogicEntity;
-import com.solidwall.tartib.entities.ComponentLogicEntity;
 import com.solidwall.tartib.implementations.ProjectLogicImplementation;
+import com.solidwall.tartib.repositories.ComponentLogicRepository;
 import com.solidwall.tartib.repositories.ProjectIdentityRepository;
 import com.solidwall.tartib.repositories.ProjectLogicRepository;
-import com.solidwall.tartib.repositories.ComponentLogicRepository;
+
+import java.net.MalformedURLException;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Transactional
+@Slf4j
 public class ProjectLogicService implements ProjectLogicImplementation {
 
-  @Autowired
-  ProjectLogicRepository ProjectLogicRepository;
+    @Value("${app.upload.project-logic-docs}")
+    private String uploadPath;
 
-  @Autowired
-  ProjectIdentityRepository projectIdentityRepository;
+    @Autowired
+    private ProjectLogicRepository projectLogicRepository;
 
-  @Autowired
-  ComponentLogicRepository ComponentLogicRepository;
+    @Autowired
+    private ProjectIdentityRepository projectIdentityRepository;
 
-  @Override
-  public ProjectLogicEntity getOne(Long id) {
-    Optional<ProjectLogicEntity> ProjectLogic = ProjectLogicRepository.findById(id);
-    if (ProjectLogic.isPresent()) {
-      return ProjectLogic.get();
-    } else {
-      throw new NotFoundException("project logic not exist");
-    }
-  }
+    @Autowired
+    private ComponentLogicRepository componentLogicRepository;
 
-  @Override
-  public ProjectLogicEntity findOne(Map<String, String> data) {
-
-    if (data.get("projectIdentity") != null) {
-      Long projectId = Long.parseLong(data.get("projectIdentity"));
-      Optional<ProjectIdentityEntity> projectIdentity = projectIdentityRepository.findById(projectId);
-      if (!projectIdentity.isPresent())
-        throw new NotFoundException("projectIdentity not found");
-      Optional<ProjectLogicEntity> ProjectLogic = ProjectLogicRepository.findByProjectIdentity(projectIdentity.get());
-      if (!ProjectLogic.isPresent())
-        throw new NotFoundException("projectIdentity logic not found");
-      return ProjectLogic.get();
-    }
-    throw new BadRequestException("param not exist");
-
-  }
-
-  @Override
-  public List<ProjectLogicEntity> findAll() {
-    if (!ProjectLogicRepository.findAll().isEmpty()) {
-      return ProjectLogicRepository.findAll();
-    } else {
-      throw new NotFoundException("not exist any project logic ");
-    }
-  }
-
-  @Override
-  public ProjectLogicEntity create(CreateDto data) {
-
-    Optional<ProjectIdentityEntity> projectidentity = projectIdentityRepository.findById(data.getProjectIdentity());
-
-    if (projectidentity.isPresent()) {
-      Optional<ProjectLogicEntity> ProjectLogic = ProjectLogicRepository.findByProjectIdentity(projectidentity.get());
-      if (ProjectLogic.isPresent()) {
-        ProjectLogicRepository.delete(ProjectLogic.get());
-      }
-
-      ProjectLogicEntity newProjectLogic = new ProjectLogicEntity();
-
-      newProjectLogic.setProjectIdentity(projectidentity.get());
-      newProjectLogic.setGeneralObjective(data.getGeneralObjective());
-      newProjectLogic.setSpecific_objective(data.getSpecific_objective());
-      newProjectLogic.setResults(data.getResults());
-      newProjectLogic.setYearEnd(data.getYearEnd());
-      newProjectLogic.setYearStart(data.getYearStart());
-      newProjectLogic.setDocumentCadre(data.getDocumentCadre());
-      newProjectLogic.setDocumentPlanTravail(data.getDocumentPlanTravail());
-
-      if (data.getComponentLogics() != null) {
-        List<ComponentLogicEntity> ComponentLogics = data.getComponentLogics().stream()
-            .map(ComponentLogicDto -> {
-              ComponentLogicEntity ComponentLogic = new ComponentLogicEntity();
-              ComponentLogic.setName(ComponentLogicDto.getName());
-              ComponentLogic.setDescription(ComponentLogicDto.getDescription());
-              ComponentLogic.setCout(ComponentLogicDto.getCout());
-
-              ComponentLogic.setProjectLogic(newProjectLogic);
-              return ComponentLogic;
-            })
-            .collect(Collectors.toList());
-        newProjectLogic.setComponentLogics(ComponentLogics);
-      }
-
-      return ProjectLogicRepository.save(newProjectLogic);
-    } else {
-      throw new NotFoundException("not exist any project identy to link this logic ");
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(Path.of(uploadPath));
+            log.info("Upload directory created/verified: {}", uploadPath);
+        } catch (IOException e) {
+            log.error("Could not create upload directory: {}", uploadPath, e);
+            throw new RuntimeException("Could not create upload directory", e);
+        }
     }
 
-  }
-
-  @Override
-  public ProjectLogicEntity update(Long id, UpdateDto data) {
-
-    Optional<ProjectLogicEntity> ProjectLogic = ProjectLogicRepository.findById(id);
-
-    if (ProjectLogic.isPresent()) {
-      ProjectLogicEntity updateProjectLogic = ProjectLogic.get();
-      updateProjectLogic.setGeneralObjective(data.getGeneralObjective());
-      updateProjectLogic.setSpecific_objective(data.getSpecific_objective());
-      updateProjectLogic.setResults(data.getResults());
-      updateProjectLogic.setYearEnd(data.getYearEnd());
-      updateProjectLogic.setYearStart(data.getYearStart());
-      updateProjectLogic.setDocumentCadre(data.getDocumentCadre());
-      updateProjectLogic.setDocumentPlanTravail(data.getDocumentPlanTravail());
-
-      if (data.getComponentLogics() != null) {
-        ComponentLogicRepository.deleteByProjectLogicId(updateProjectLogic.getId());
-        List<ComponentLogicEntity> ComponentLogics = data.getComponentLogics().stream()
-            .map(ComponentLogicDto -> {
-              ComponentLogicEntity ComponentLogic = new ComponentLogicEntity();
-              ComponentLogic.setProjectLogic(updateProjectLogic);
-              ComponentLogic.setName(ComponentLogicDto.getName());
-              ComponentLogic.setDescription(ComponentLogicDto.getDescription());
-              ComponentLogic.setCout(ComponentLogicDto.getCout());
-              return ComponentLogic;
-            })
-            .collect(Collectors.toList());
-        updateProjectLogic.setComponentLogics(ComponentLogics);
-      }
-
-      return ProjectLogicRepository.save(updateProjectLogic);
-    } else {
-      throw new NotFoundException("project logic not found");
-    }
-  }
-
-  @Override
-  public void delete(Long id) {
-    Optional<ProjectLogicEntity> ProjectLogic = ProjectLogicRepository.findById(id);
-    if (ProjectLogic.isPresent()) {
-      ProjectLogicRepository.deleteById(id);
-    } else {
-      throw new NotFoundException("project logic not exist");
-    }
-  }
-
-  @Override
-  public Long getSommeComposant(Long id) {
-    Optional<ProjectLogicEntity> projectLogicOptional = ProjectLogicRepository.findById(id);
-    long somme = 0;
-    ProjectLogicEntity projectLogic = projectLogicOptional
-        .orElseThrow(() -> new NotFoundException("Project logic not found"));
-
-    // Get component logics and calculate sum
-    if (projectLogic.getComponentLogics() != null) {
-      somme = projectLogic.getComponentLogics().stream()
-          .mapToLong(ComponentLogicEntity::getCout) // Directly map to long for sum
-          .sum(); // Sum all values
+    @Override
+    public ProjectLogicEntity getOne(Long id) {
+        return projectLogicRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("project logic not exist"));
     }
 
-    return somme;
-  }
+    @Override
+    public ProjectLogicEntity findOne(Map<String, String> data) {
+        if (data.get("projectIdentity") != null) {
+            Long projectId = Long.parseLong(data.get("projectIdentity"));
+            ProjectIdentityEntity projectIdentity = projectIdentityRepository.findById(projectId)
+                    .orElseThrow(() -> new NotFoundException("projectIdentity not found"));
+            return projectLogicRepository.findByProjectIdentity(projectIdentity)
+                    .orElseThrow(() -> new NotFoundException("projectIdentity logic not found"));
+        }
+        throw new BadRequestException("param not exist");
+    }
 
+    @Override
+    public List<ProjectLogicEntity> findAll() {
+        return projectLogicRepository.findAll();
+    }
+
+    @Override
+    public ProjectLogicEntity create(CreateDto data) {
+        ProjectIdentityEntity projectIdentity = projectIdentityRepository.findById(data.getProjectIdentity())
+                .orElseThrow(() -> new NotFoundException("not exist any project identy to link this logic "));
+
+        projectLogicRepository.findByProjectIdentity(projectIdentity).ifPresent(projectLogicRepository::delete);
+
+        ProjectLogicEntity newProjectLogic = new ProjectLogicEntity();
+        newProjectLogic.setProjectIdentity(projectIdentity);
+        newProjectLogic.setGeneralObjective(data.getGeneralObjective());
+        newProjectLogic.setSpecific_objective(data.getSpecific_objective());
+        newProjectLogic.setResults(data.getResults());
+        newProjectLogic.setYearEnd(data.getYearEnd());
+        newProjectLogic.setYearStart(data.getYearStart());
+
+        if (data.getDocumentCadreFile() != null) {
+            String filePath = handleFileUpload(data.getDocumentCadreFile(), "cadre", projectIdentity.getId());
+            newProjectLogic.setDocumentCadre(filePath);
+        }
+
+        if (data.getDocumentPlanTravailFile() != null) {
+            String filePath = handleFileUpload(data.getDocumentPlanTravailFile(), "plan_travail", projectIdentity.getId());
+            newProjectLogic.setDocumentPlanTravail(filePath);
+        }
+
+        if (data.getComponentLogics() != null) {
+            List<ComponentLogicEntity> componentLogics = data.getComponentLogics().stream()
+                    .map(componentLogicDto -> {
+                        ComponentLogicEntity componentLogic = new ComponentLogicEntity();
+                        componentLogic.setName(componentLogicDto.getName());
+                        componentLogic.setDescription(componentLogicDto.getDescription());
+                        componentLogic.setCout(componentLogicDto.getCout());
+                        componentLogic.setProjectLogic(newProjectLogic);
+                        return componentLogic;
+                    })
+                    .collect(Collectors.toList());
+            newProjectLogic.setComponentLogics(componentLogics);
+        }
+
+        return projectLogicRepository.save(newProjectLogic);
+    }
+
+    @Override
+    public ProjectLogicEntity update(Long id, UpdateDto data) {
+        ProjectLogicEntity updateProjectLogic = getOne(id);
+        updateProjectLogic.setGeneralObjective(data.getGeneralObjective());
+        updateProjectLogic.setSpecific_objective(data.getSpecific_objective());
+        updateProjectLogic.setResults(data.getResults());
+        updateProjectLogic.setYearEnd(data.getYearEnd());
+        updateProjectLogic.setYearStart(data.getYearStart());
+
+        if (data.getDocumentCadreFile() != null) {
+            deleteFileIfExists(updateProjectLogic.getDocumentCadre());
+            String filePath = handleFileUpload(data.getDocumentCadreFile(), "cadre", updateProjectLogic.getProjectIdentity().getId());
+            updateProjectLogic.setDocumentCadre(filePath);
+        }
+
+        if (data.getDocumentPlanTravailFile() != null) {
+            deleteFileIfExists(updateProjectLogic.getDocumentPlanTravail());
+            String filePath = handleFileUpload(data.getDocumentPlanTravailFile(), "plan_travail", updateProjectLogic.getProjectIdentity().getId());
+            updateProjectLogic.setDocumentPlanTravail(filePath);
+        }
+
+        if (data.getComponentLogics() != null) {
+            componentLogicRepository.deleteByProjectLogicId(updateProjectLogic.getId());
+            List<ComponentLogicEntity> componentLogics = data.getComponentLogics().stream()
+                    .map(componentLogicDto -> {
+                        ComponentLogicEntity componentLogic = new ComponentLogicEntity();
+                        componentLogic.setProjectLogic(updateProjectLogic);
+                        componentLogic.setName(componentLogicDto.getName());
+                        componentLogic.setDescription(componentLogicDto.getDescription());
+                        componentLogic.setCout(componentLogicDto.getCout());
+                        return componentLogic;
+                    })
+                    .collect(Collectors.toList());
+            updateProjectLogic.setComponentLogics(componentLogics);
+        }
+
+        return projectLogicRepository.save(updateProjectLogic);
+    }
+
+    @Override
+    public void delete(Long id) {
+        ProjectLogicEntity projectLogic = getOne(id);
+        deleteFileIfExists(projectLogic.getDocumentCadre());
+        deleteFileIfExists(projectLogic.getDocumentPlanTravail());
+        projectLogicRepository.delete(projectLogic);
+    }
+
+    @Override
+    public Long getSommeComposant(Long id) {
+        ProjectLogicEntity projectLogic = getOne(id);
+        long somme = 0;
+        if (projectLogic.getComponentLogics() != null) {
+            somme = projectLogic.getComponentLogics().stream()
+                    .mapToLong(ComponentLogicEntity::getCout)
+                    .sum();
+        }
+        return somme;
+    }
+
+    private String handleFileUpload(MultipartFile file, String fileType, Long projectId) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String extension = originalFilename != null
+                    ? originalFilename.substring(originalFilename.lastIndexOf(".") + 1)
+                    : "";
+            String fileName = String.format("project_%d_%s_%d.%s", projectId, fileType,
+                    System.currentTimeMillis(), extension);
+            Path targetLocation = Path.of(uploadPath, fileName);
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            return fileName;
+        } catch (IOException ex) {
+            throw new FileStorageException("Could not store file", ex);
+        }
+    }
+
+    private void deleteFileIfExists(String filePath) {
+        if (filePath != null && !filePath.isEmpty()) {
+            try {
+                Files.deleteIfExists(Path.of(uploadPath, filePath));
+            } catch (IOException ex) {
+                log.error("Error deleting file: {}", filePath, ex);
+            }
+        }
+    }
+
+    public Resource downloadDocumentCadreFile(Long id) {
+        try {
+            ProjectLogicEntity projectLogic = getOne(id);
+
+            if (projectLogic.getDocumentCadre() == null || projectLogic.getDocumentCadre().isEmpty()) {
+                throw new NotFoundException("No document cadre file found for this project logic");
+            }
+
+            Path filePath = Path.of(uploadPath, projectLogic.getDocumentCadre());
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new NotFoundException("File not found or not readable");
+            }
+
+            return resource;
+        } catch (MalformedURLException e) {
+            throw new FileStorageException("Error: " + e.getMessage());
+        }
+    }
+
+    public Resource downloadDocumentPlanTravailFile(Long id) {
+        try {
+            ProjectLogicEntity projectLogic = getOne(id);
+
+            if (projectLogic.getDocumentPlanTravail() == null || projectLogic.getDocumentPlanTravail().isEmpty()) {
+                throw new NotFoundException("No document plan travail file found for this project logic");
+            }
+
+            Path filePath = Path.of(uploadPath, projectLogic.getDocumentPlanTravail());
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new NotFoundException("File not found or not readable");
+            }
+
+            return resource;
+        } catch (MalformedURLException e) {
+            throw new FileStorageException("Error: " + e.getMessage());
+        }
+    }
+
+    public String determineContentType(String filename) {
+        if (filename.toLowerCase().endsWith(".pdf")) {
+            return "application/pdf";
+        } else if (filename.toLowerCase().endsWith(".doc")) {
+            return "application/msword";
+        } else if (filename.toLowerCase().endsWith(".docx")) {
+            return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        } else {
+            return "application/octet-stream";
+        }
+    }
 }

--- a/src/main/java/com/solidwall/tartib/services/ProjectPlanService.java
+++ b/src/main/java/com/solidwall/tartib/services/ProjectPlanService.java
@@ -1,242 +1,289 @@
 package com.solidwall.tartib.services;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.*;
 import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.solidwall.tartib.core.exceptions.BadRequestException;
+import com.solidwall.tartib.core.exceptions.FileStorageException;
 import com.solidwall.tartib.core.exceptions.FoundException;
 import com.solidwall.tartib.core.exceptions.NotFoundException;
 import com.solidwall.tartib.dto.project.plan.CreateDto;
 import com.solidwall.tartib.dto.project.plan.UpdateDto;
-import com.solidwall.tartib.entities.FundingSourceTypeEntity;
+import com.solidwall.tartib.entities.FinancialSourceEntity;
 import com.solidwall.tartib.entities.ProjectIdentityEntity;
-import com.solidwall.tartib.entities.ProjectLogicEntity;
 import com.solidwall.tartib.entities.ProjectPlanEntity;
 import com.solidwall.tartib.entities.ProjectScaleEntity;
 import com.solidwall.tartib.entities.RubriqueEntity;
-import com.solidwall.tartib.entities.StakeHolderEntity;
-import com.solidwall.tartib.entities.FinancialSourceEntity;
 import com.solidwall.tartib.implementations.ProjectPlanImplementation;
 import com.solidwall.tartib.repositories.FinancialSourceRepository;
-import com.solidwall.tartib.repositories.FundingSourceRepository;
-import com.solidwall.tartib.repositories.FundingSourceTypeRepository;
 import com.solidwall.tartib.repositories.ProjectIdentityRepository;
-import com.solidwall.tartib.repositories.ProjectLogicRepository;
 import com.solidwall.tartib.repositories.ProjectPlanRepository;
 import com.solidwall.tartib.repositories.ProjectScaleRepository;
 import com.solidwall.tartib.repositories.RubriqueRepository;
 
+import java.net.MalformedURLException;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Transactional
+@Slf4j
 public class ProjectPlanService implements ProjectPlanImplementation {
 
-  @Autowired
-  ProjectIdentityRepository projectIdentityRepository;
+    @Value("${app.upload.project-plan-docs}")
+    private String uploadPath;
 
-  @Autowired
-  ProjectPlanRepository projectPlanRepository;
+    @Autowired
+    private ProjectPlanRepository projectPlanRepository;
 
-  @Autowired
-  FinancialSourceRepository financialSourceRepository;
+    @Autowired
+    private ProjectIdentityRepository projectIdentityRepository;
 
-  @Autowired
-  RubriqueRepository rubriqueRepository;
+    @Autowired
+    private FinancialSourceRepository financialSourceRepository;
 
-  @Autowired
-  ProjectScaleRepository projectScaleRepository;
+    @Autowired
+    private RubriqueRepository rubriqueRepository;
 
-  @Autowired
-  ProjectScaleService prokScaleService;
+    @Autowired
+    private ProjectScaleRepository projectScaleRepository;
 
-  @Override
-  public List<ProjectPlanEntity> findAll() {
-    if (!projectPlanRepository.findAll().isEmpty()) {
-      return projectPlanRepository.findAll();
-    } else {
-      throw new NotFoundException("not exist any project plan ");
-    }
-  }
-
-  @Override
-  public ProjectPlanEntity getOne(Long id) {
-    Optional<ProjectPlanEntity> projectPlan = projectPlanRepository.findById(id);
-    if (projectPlan.isPresent()) {
-      return projectPlan.get();
-    } else {
-      throw new NotFoundException("project plan not exist");
-    }
-  }
-
-  @Override
-  public ProjectPlanEntity findOne(Map<String, String> data) {
-    if (data.get("projectIdentity") != null) {
-      Long projectId = Long.parseLong(data.get("projectIdentity"));
-      Optional<ProjectIdentityEntity> projectIdentity = projectIdentityRepository.findById(projectId);
-      if (!projectIdentity.isPresent())
-        // throw new NotFoundException("project plan not found");
-        return null;
-      Optional<ProjectPlanEntity> projectPlan = projectPlanRepository.findByProjectIdentity(projectIdentity.get());
-      // if (!projectPlan.isPresent())
-      //   throw new NotFoundException("project plan not found");
-      return projectPlan.orElse(null);
-    }
-    throw new BadRequestException("param not exist");
-  }
-
-  @Override
-  public ProjectPlanEntity create(CreateDto data) {
-
-    Optional<ProjectIdentityEntity> project = projectIdentityRepository.findById(data.getProjectIdentity());
-
-    if (project.isPresent()) {
-      ProjectPlanEntity newProjectPlan = new ProjectPlanEntity();
-      newProjectPlan.setProjectIdentity(project.get());
-      newProjectPlan.setCoutTotale(data.getCoutTotale());
-      newProjectPlan.setCoutDinars(data.getCoutDinars());
-      newProjectPlan.setMontantAnnuel(data.getMontantAnnuel());
-      newProjectPlan.setObservation(data.getObservation());
-      newProjectPlan.setTauxEchange(data.getTauxEchange());
-
-      if (data.getFinancialSource() != null) {
-        List<FinancialSourceEntity> financialSources = data.getFinancialSource().stream()
-            .map(financialSourceDto -> {
-              FinancialSourceEntity financialSource = new FinancialSourceEntity();
-              financialSource.setBailleur(financialSourceDto.getBailleur());
-              financialSource.setStatut(financialSourceDto.getStatut());
-              financialSource.setTauxEchange(financialSourceDto.getTauxEchange());
-              financialSource.setDevise(financialSourceDto.getDevise());
-              financialSource.setType(financialSourceDto.getType());
-              financialSource.setMontant(financialSourceDto.getMontant());
-              financialSource.setMontantDinars(financialSourceDto.getMontantDinars());
-              financialSource.setProjectPlan(newProjectPlan);
-              return financialSource;
-            })
-            .collect(Collectors.toList());
-        newProjectPlan.setFinancialSource(financialSources);
-      }
-
-      if (data.getRubriques() != null) {
-        List<RubriqueEntity> rubriques = data.getRubriques().stream()
-            .map(rubriqueDTO -> {
-              RubriqueEntity rub = new RubriqueEntity();
-              rub.setAmount(rubriqueDTO.getAmount());
-              rub.setName(rubriqueDTO.getName());
-              rub.setProjectPlan(newProjectPlan);
-              return rub;
-            })
-            .collect(Collectors.toList());
-        newProjectPlan.setRubriques(rubriques);
-      }
-
-      ProjectScaleEntity scale = projectScaleRepository
-          .findByMinimumBudgetLessThanEqualAndMaximumBudgetGreaterThanEqual(data.getCoutTotale(), data.getCoutTotale());
-      List<ProjectScaleEntity> projectScaleEntitycheck = projectScaleRepository
-          .findByMaximumBudgetAndMinimumBudget(scale.getMinimumBudget(), scale.getMaximumBudget());
-
-      if (!projectScaleEntitycheck.isEmpty() && !projectScaleEntitycheck.contains(scale) ) {
-        throw new FoundException("cet intervale intersect avec un autre intervalle du budget");
-      }
-
-      ProjectIdentityEntity identity = projectIdentityRepository.findById(data.getProjectIdentity()).get();
-
-      scale.setProjectIdentity(identity);
-      projectScaleRepository.save(scale);
-
-      Optional<ProjectPlanEntity> ProjectPlan = projectPlanRepository.findByProjectIdentity(identity);
-      if (ProjectPlan.isPresent()) {
-        projectPlanRepository.delete(ProjectPlan.get());
-      }
-
-      return projectPlanRepository.save(newProjectPlan);
-    } else {
-      throw new NotFoundException("project not found");
+    @PostConstruct
+    public void init() {
+        try {
+            Files.createDirectories(Path.of(uploadPath));
+            log.info("Upload directory created/verified: {}", uploadPath);
+        } catch (IOException e) {
+            log.error("Could not create upload directory: {}", uploadPath, e);
+            throw new RuntimeException("Could not create upload directory", e);
+        }
     }
 
-  }
-
-  @Override
-  @Transactional
-  public ProjectPlanEntity update(Long id, UpdateDto data) {
-      Optional<ProjectPlanEntity> projectPlan = projectPlanRepository.findById(id);
-      Optional<ProjectIdentityEntity> project = projectIdentityRepository.findById(data.getProjectIdentity());
-  
-      if (projectPlan.isPresent() && project.isPresent()) {
-          ProjectPlanEntity updateProjectPlan = projectPlan.get();
-          
-          // Basic fields update
-          updateProjectPlan.setProjectIdentity(project.get());
-          updateProjectPlan.setCoutTotale(data.getCoutTotale());
-          updateProjectPlan.setCoutDinars(data.getCoutDinars());
-          updateProjectPlan.setMontantAnnuel(data.getMontantAnnuel());
-          updateProjectPlan.setObservation(data.getObservation());
-          updateProjectPlan.setTauxEchange(data.getTauxEchange());
-  
-          // Handle financial sources - ONE approach, not both
-          if (data.getFinancialSource() != null) {
-              // First, remove old associations 
-              financialSourceRepository.deleteByProjectPlanId(updateProjectPlan.getId());
-              
-              // Now make a new collection - don't modify the existing one
-              List<FinancialSourceEntity> financialSources = data.getFinancialSource().stream()
-                  .map(financialSourceDto -> {
-                      FinancialSourceEntity financialSource = new FinancialSourceEntity();
-                      financialSource.setStatut(financialSourceDto.getStatut());
-                      financialSource.setTauxEchange(financialSourceDto.getTauxEchange());
-                      financialSource.setBailleur(financialSourceDto.getBailleur());
-                      financialSource.setType(financialSourceDto.getType());
-                      financialSource.setDevise(financialSourceDto.getDevise());
-                      financialSource.setMontant(financialSourceDto.getMontant());
-                      financialSource.setMontantDinars(financialSourceDto.getMontantDinars());
-                      financialSource.setProjectPlan(updateProjectPlan);
-                      return financialSource;
-                  })
-                  .collect(Collectors.toList());
-              
-              // Replace the collection entirely
-              updateProjectPlan.setFinancialSource(financialSources);
-          }
-  
-          // Similar approach for rubriques
-          if (data.getRubriques() != null) {
-              // First, remove old associations
-              rubriqueRepository.deleteByProjectPlanId(updateProjectPlan.getId());
-              
-              // Create new collection
-              List<RubriqueEntity> rubriques = data.getRubriques().stream()
-                  .map(rubriqueDTO -> {
-                      RubriqueEntity rub = new RubriqueEntity();
-                      rub.setAmount(rubriqueDTO.getAmount());
-                      rub.setName(rubriqueDTO.getName());
-                      rub.setProjectPlan(updateProjectPlan);
-                      return rub;
-                  })
-                  .collect(Collectors.toList());
-              
-              // Replace the collection entirely
-              updateProjectPlan.setRubriques(rubriques);
-          }
-  
-          // Rest of your existing code...
-          
-          return projectPlanRepository.save(updateProjectPlan);
-      } else {
-          throw new NotFoundException("project plan not found");
-      }
-  }
-  
-  @Override
-  public void delete(Long id) {
-    Optional<ProjectPlanEntity> projectPlan = projectPlanRepository.findById(id);
-    if (projectPlan.isPresent()) {
-      projectPlanRepository.deleteById(id);
-    } else {
-      throw new NotFoundException("project plan not exist");
+    @Override
+    public List<ProjectPlanEntity> findAll() {
+        return projectPlanRepository.findAll();
     }
-  }
+
+    @Override
+    public ProjectPlanEntity getOne(Long id) {
+        return projectPlanRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("project plan not exist"));
+    }
+
+    @Override
+    public ProjectPlanEntity findOne(Map<String, String> data) {
+        if (data.get("projectIdentity") != null) {
+            Long projectId = Long.parseLong(data.get("projectIdentity"));
+            ProjectIdentityEntity projectIdentity = projectIdentityRepository.findById(projectId)
+                    .orElse(null);
+            if (projectIdentity == null) {
+                return null;
+            }
+            return projectPlanRepository.findByProjectIdentity(projectIdentity).orElse(null);
+        }
+        throw new BadRequestException("param not exist");
+    }
+
+    @Override
+    public ProjectPlanEntity create(CreateDto data) {
+        ProjectIdentityEntity project = projectIdentityRepository.findById(data.getProjectIdentity())
+                .orElseThrow(() -> new NotFoundException("project not found"));
+
+        ProjectPlanEntity newProjectPlan = new ProjectPlanEntity();
+        newProjectPlan.setProjectIdentity(project);
+        newProjectPlan.setCoutTotale(data.getCoutTotale());
+        newProjectPlan.setCoutDinars(data.getCoutDinars());
+        newProjectPlan.setMontantAnnuel(data.getMontantAnnuel());
+        newProjectPlan.setObservation(data.getObservation());
+        newProjectPlan.setTauxEchange(data.getTauxEchange());
+
+        if (data.getPlanFinancementFile() != null) {
+            String filePath = handleFileUpload(data.getPlanFinancementFile(), project.getId());
+            newProjectPlan.setPlanFinancement(filePath);
+        }
+
+        if (data.getFinancialSource() != null) {
+            List<FinancialSourceEntity> financialSources = data.getFinancialSource().stream()
+                    .map(financialSourceDto -> {
+                        FinancialSourceEntity financialSource = new FinancialSourceEntity();
+                        financialSource.setBailleur(financialSourceDto.getBailleur());
+                        financialSource.setStatut(financialSourceDto.getStatut());
+                        financialSource.setTauxEchange(financialSourceDto.getTauxEchange());
+                        financialSource.setDevise(financialSourceDto.getDevise());
+                        financialSource.setType(financialSourceDto.getType());
+                        financialSource.setMontant(financialSourceDto.getMontant());
+                        financialSource.setMontantDinars(financialSourceDto.getMontantDinars());
+                        financialSource.setProjectPlan(newProjectPlan);
+                        return financialSource;
+                    })
+                    .collect(Collectors.toList());
+            newProjectPlan.setFinancialSource(financialSources);
+        }
+
+        if (data.getRubriques() != null) {
+            List<RubriqueEntity> rubriques = data.getRubriques().stream()
+                    .map(rubriqueDTO -> {
+                        RubriqueEntity rub = new RubriqueEntity();
+                        rub.setAmount(rubriqueDTO.getAmount());
+                        rub.setName(rubriqueDTO.getName());
+                        rub.setProjectPlan(newProjectPlan);
+                        return rub;
+                    })
+                    .collect(Collectors.toList());
+            newProjectPlan.setRubriques(rubriques);
+        }
+
+        ProjectScaleEntity scale = projectScaleRepository
+                .findByMinimumBudgetLessThanEqualAndMaximumBudgetGreaterThanEqual(data.getCoutTotale(),
+                        data.getCoutTotale());
+        if (scale != null) {
+            List<ProjectScaleEntity> projectScaleEntitycheck = projectScaleRepository
+                    .findByMaximumBudgetAndMinimumBudget(scale.getMinimumBudget(), scale.getMaximumBudget());
+            if (!projectScaleEntitycheck.isEmpty() && !projectScaleEntitycheck.contains(scale)) {
+                throw new FoundException("cet intervale intersect avec un autre intervalle du budget");
+            }
+            scale.setProjectIdentity(project);
+            projectScaleRepository.save(scale);
+        }
+
+        projectPlanRepository.findByProjectIdentity(project).ifPresent(projectPlanRepository::delete);
+
+        return projectPlanRepository.save(newProjectPlan);
+    }
+
+    @Override
+    @Transactional
+    public ProjectPlanEntity update(Long id, UpdateDto data) {
+        ProjectPlanEntity updateProjectPlan = getOne(id);
+        ProjectIdentityEntity project = projectIdentityRepository.findById(data.getProjectIdentity())
+                .orElseThrow(() -> new NotFoundException("project not found"));
+
+        updateProjectPlan.setProjectIdentity(project);
+        updateProjectPlan.setCoutTotale(data.getCoutTotale());
+        updateProjectPlan.setCoutDinars(data.getCoutDinars());
+        updateProjectPlan.setMontantAnnuel(data.getMontantAnnuel());
+        updateProjectPlan.setObservation(data.getObservation());
+        updateProjectPlan.setTauxEchange(data.getTauxEchange());
+
+        if (data.getPlanFinancementFile() != null) {
+            deleteFileIfExists(updateProjectPlan.getPlanFinancement());
+            String filePath = handleFileUpload(data.getPlanFinancementFile(), project.getId());
+            updateProjectPlan.setPlanFinancement(filePath);
+        }
+
+        if (data.getFinancialSource() != null) {
+            financialSourceRepository.deleteByProjectPlanId(updateProjectPlan.getId());
+            List<FinancialSourceEntity> financialSources = data.getFinancialSource().stream()
+                    .map(financialSourceDto -> {
+                        FinancialSourceEntity financialSource = new FinancialSourceEntity();
+                        financialSource.setStatut(financialSourceDto.getStatut());
+                        financialSource.setTauxEchange(financialSourceDto.getTauxEchange());
+                        financialSource.setBailleur(financialSourceDto.getBailleur());
+                        financialSource.setType(financialSourceDto.getType());
+                        financialSource.setDevise(financialSourceDto.getDevise());
+                        financialSource.setMontant(financialSourceDto.getMontant());
+                        financialSource.setMontantDinars(financialSourceDto.getMontantDinars());
+                        financialSource.setProjectPlan(updateProjectPlan);
+                        return financialSource;
+                    })
+                    .collect(Collectors.toList());
+            updateProjectPlan.setFinancialSource(financialSources);
+        }
+
+        if (data.getRubriques() != null) {
+            rubriqueRepository.deleteByProjectPlanId(updateProjectPlan.getId());
+            List<RubriqueEntity> rubriques = data.getRubriques().stream()
+                    .map(rubriqueDTO -> {
+                        RubriqueEntity rub = new RubriqueEntity();
+                        rub.setAmount(rubriqueDTO.getAmount());
+                        rub.setName(rubriqueDTO.getName());
+                        rub.setProjectPlan(updateProjectPlan);
+                        return rub;
+                    })
+                    .collect(Collectors.toList());
+            updateProjectPlan.setRubriques(rubriques);
+        }
+
+        return projectPlanRepository.save(updateProjectPlan);
+    }
+
+    @Override
+    public void delete(Long id) {
+        ProjectPlanEntity projectPlan = getOne(id);
+        deleteFileIfExists(projectPlan.getPlanFinancement());
+        projectPlanRepository.delete(projectPlan);
+    }
+
+    private String handleFileUpload(MultipartFile file, Long projectId) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String extension = originalFilename != null
+                    ? originalFilename.substring(originalFilename.lastIndexOf(".") + 1)
+                    : "";
+            String fileName = String.format("project_%d_plan_financement_%d.%s", projectId,
+                    System.currentTimeMillis(), extension);
+            Path targetLocation = Path.of(uploadPath, fileName);
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            return fileName;
+        } catch (IOException ex) {
+            throw new FileStorageException("Could not store file", ex);
+        }
+    }
+
+    private void deleteFileIfExists(String filePath) {
+        if (filePath != null && !filePath.isEmpty()) {
+            try {
+                Files.deleteIfExists(Path.of(uploadPath, filePath));
+            } catch (IOException ex) {
+                log.error("Error deleting file: {}", filePath, ex);
+            }
+        }
+    }
+
+    public Resource downloadPlanFinancementFile(Long id) {
+        try {
+            ProjectPlanEntity projectPlan = getOne(id);
+
+            if (projectPlan.getPlanFinancement() == null || projectPlan.getPlanFinancement().isEmpty()) {
+                throw new NotFoundException("No plan financement file found for this project plan");
+            }
+
+            Path filePath = Path.of(uploadPath, projectPlan.getPlanFinancement());
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new NotFoundException("File not found or not readable");
+            }
+
+            return resource;
+        } catch (MalformedURLException e) {
+            throw new FileStorageException("Error: " + e.getMessage());
+        }
+    }
+
+    public String determineContentType(String filename) {
+        if (filename.toLowerCase().endsWith(".pdf")) {
+            return "application/pdf";
+        } else if (filename.toLowerCase().endsWith(".doc")) {
+            return "application/msword";
+        } else if (filename.toLowerCase().endsWith(".docx")) {
+            return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        } else {
+            return "application/octet-stream";
+        }
+    }
 }


### PR DESCRIPTION
This commit builds upon the previous file management implementation by adding download capabilities to all recently modified entities and completing the file management implementation for the remaining entities.

Key changes include:

**Download Functionality:**
- Implemented download endpoints for the following entities:
  - `NomenclatureGeographic`: `GET /nomenclature-geo/download/{id}`
  - `AutorisationEntity`: `GET /autorisation/download/{id}`
  - `StudyForProject`: `GET /study-for-project/download/{id}`
  - `ProjectLogicEntity`:
    - `GET /project-logic/download/cadre/{id}`
    - `GET /project-logic/download/plan-travail/{id}`
  - `ProjectPlanEntity`: `GET /project-plan/download/{id}`
- Added corresponding methods in the service layer for each entity to handle the file retrieval from the filesystem.

**`ProjectLogicEntity` File Management:**
- Completed the file management implementation by updating the service and controller to handle uploads and downloads for both `documentCadre` and `documentPlanTravail` files.

**`ProjectPlanEntity` File Management:**
- Completed the file management implementation by adding a `planFinancement` field, updating the service to handle uploads and deletes, and updating the controller for multipart requests.

All related DTOs, services, and controllers have been updated accordingly.